### PR TITLE
use a static feature bundle

### DIFF
--- a/bin/simple-backuper
+++ b/bin/simple-backuper
@@ -4,7 +4,7 @@ package App::SimpleBackuper;
 
 use strict;
 use warnings;
-use feature ':5.'.substr($], 3, 2);
+use feature ':5.14';
 use Getopt::Long;
 use JSON::PP;
 use Try::Tiny;

--- a/lib/App/SimpleBackuper/Backup.pm
+++ b/lib/App/SimpleBackuper/Backup.pm
@@ -2,7 +2,7 @@ package App::SimpleBackuper;
 
 use strict;
 use warnings;
-use feature ':5.'.substr($], 3, 2);
+use feature ':5.14';
 use Carp;
 use Try::Tiny;
 use Time::HiRes qw(time);

--- a/lib/App/SimpleBackuper/DB/BlocksTable.pm
+++ b/lib/App/SimpleBackuper/DB/BlocksTable.pm
@@ -2,7 +2,7 @@ package App::SimpleBackuper::DB::BlocksTable;
 
 use strict;
 use warnings;
-use feature ':5.'.substr($], 3, 2);
+use feature ':5.14';
 use parent qw(App::SimpleBackuper::DB::BaseTable);
 
 sub pack {


### PR DESCRIPTION
Always using the latest feature bundle will end up enabling any new
feature that may not be compatible with the rest of the code. That is
why the features are not enabled by default.

The signatures feature has gone stable with perl 5.36, so it has been
added to the feature bundle. This is not compatible with code using
prototypes, as they have overlapping syntax. One of the modules in this
dist is using prototypes, so enabling the latest feature bundle will
break the code on 5.36.

Replace the dynamic feature bundle selection with a static feature
bundle. Since dist defines a minimum perl version of 5.14, enabling the
5.14 feature bundle seems most appropriate.